### PR TITLE
Add ASync Methods

### DIFF
--- a/doc/Okolni.Source.Example/Program.cs
+++ b/doc/Okolni.Source.Example/Program.cs
@@ -11,7 +11,7 @@ namespace Okolni.Source.Example
         {
             IQueryConnection conn = new QueryConnection();
 
-            conn.Host = "127.0.0.1";
+            conn.Host = "192.0.2.0";
             conn.Port = 27015;
 
             conn.Connect();
@@ -32,6 +32,9 @@ namespace Okolni.Source.Example
             Console.WriteLine($"Current players: {string.Join("; ", playersAsync.Players.Select(p => p.Name))}");
             var rulesAsync = await conn.GetRulesAsync();
             Console.WriteLine($"Rules: {string.Join("; ", rulesAsync.Rules.Select(r => $"{r.Key}: {r.Value}"))}");
+
+            // Disposes Socket
+            conn.Disconnect();
 
         }
     }

--- a/doc/Okolni.Source.Example/Program.cs
+++ b/doc/Okolni.Source.Example/Program.cs
@@ -1,12 +1,13 @@
 ﻿using Okolni.Source.Query;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Okolni.Source.Example
 {
     public class Program
     {
-        static void Main(string[] args)
+        async static Task Main(string[] args)
         {
             IQueryConnection conn = new QueryConnection();
 
@@ -21,6 +22,17 @@ namespace Okolni.Source.Example
             Console.WriteLine($"Current players: {string.Join("; ", players.Players.Select(p => p.Name))}");
             var rules = conn.GetRules();
             Console.WriteLine($"Rules: {string.Join("; ", rules.Rules.Select(r => $"{r.Key}: {r.Value}"))}");
+
+
+
+
+            var infoAsync = await conn.GetInfoAsync();
+            Console.WriteLine($"Server info: {infoAsync.ToString()}");
+            var playersAsync = await conn.GetPlayersAsync();
+            Console.WriteLine($"Current players: {string.Join("; ", playersAsync.Players.Select(p => p.Name))}");
+            var rulesAsync = await conn.GetRulesAsync();
+            Console.WriteLine($"Rules: {string.Join("; ", rulesAsync.Rules.Select(r => $"{r.Key}: {r.Value}"))}");
+
         }
     }
 }

--- a/src/Okolni.Source.Query.Test/FunctionalTests.cs
+++ b/src/Okolni.Source.Query.Test/FunctionalTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Okolni.Source.Query;
 using Okolni.Source.Common;
@@ -30,7 +32,7 @@ namespace Okolni.Source.Query.Test
         }
 
         [TestMethod]
-        public void AsyncQueryTest()
+        public async Task AsyncQueryTest()
         {
             IQueryConnection conn = new QueryConnection();
 
@@ -40,12 +42,28 @@ namespace Okolni.Source.Query.Test
 
             conn.Connect();
 
-            var players = conn.GetPlayersAsync();
-            var info = conn.GetInfoAsync();
-            var rules = conn.GetRulesAsync();
+            var players = await conn.GetPlayersAsync();
+            var info = await conn.GetInfoAsync();
+            var rules = await conn.GetRulesAsync();
             Assert.IsNotNull(players);
             Assert.IsNotNull(info);
             Assert.IsNotNull(rules);
+        }
+
+        [TestMethod]
+        //192.0.2.0/24 is reserved documentation range
+        [DataRow("192.0.2.0", 27015)]
+        public async Task QueryTestFailCondition(string Host, int Port)
+        {
+            IQueryConnection conn = new QueryConnection();
+            conn.Host = Host;
+            conn.Port = Port;
+
+            conn.Connect();
+
+
+            await Assert.ThrowsExceptionAsync<SourceQueryException>(async () =>
+                await conn.GetInfoAsync());
         }
     }
 }

--- a/src/Okolni.Source.Query.Test/FunctionalTests.cs
+++ b/src/Okolni.Source.Query.Test/FunctionalTests.cs
@@ -23,7 +23,7 @@ namespace Okolni.Source.Query.Test
             var players2 = conn.GetPlayers();
             Assert.IsNotNull(players1);
             Assert.IsNotNull(players2);
-            //conn.Disconnect();
+            conn.Disconnect();
             // Console.WriteLine(players1.ToString());
             // Console.WriteLine(players2.ToString());
             // Console.WriteLine(players3.ToString());
@@ -48,6 +48,7 @@ namespace Okolni.Source.Query.Test
             Assert.IsNotNull(players);
             Assert.IsNotNull(info);
             Assert.IsNotNull(rules);
+            conn.Disconnect();
         }
 
         [TestMethod]
@@ -64,6 +65,7 @@ namespace Okolni.Source.Query.Test
 
             await Assert.ThrowsExceptionAsync<SourceQueryException>(async () =>
                 await conn.GetInfoAsync());
+            conn.Disconnect();
         }
     }
 }

--- a/src/Okolni.Source.Query.Test/FunctionalTests.cs
+++ b/src/Okolni.Source.Query.Test/FunctionalTests.cs
@@ -12,20 +12,40 @@ namespace Okolni.Source.Query.Test
         {
             IQueryConnection conn = new QueryConnection();
 
-            // Exampleserver: ARK VALGUERO Server
-            conn.Host = "89.163.146.91";
-            conn.Port = 27023;
+            // Random Server - Should find more stable one?
+            conn.Host = "185.239.211.62";
+            conn.Port = 39215;
 
             conn.Connect();
             var players1 = conn.GetPlayers();
             var players2 = conn.GetPlayers();
-
+            Assert.IsNotNull(players1);
+            Assert.IsNotNull(players2);
             //conn.Disconnect();
             // Console.WriteLine(players1.ToString());
             // Console.WriteLine(players2.ToString());
             // Console.WriteLine(players3.ToString());
             // Console.WriteLine(players4.ToString());
             // Console.WriteLine(players5.ToString());
+        }
+
+        [TestMethod]
+        public void AsyncQueryTest()
+        {
+            IQueryConnection conn = new QueryConnection();
+
+            // Random Server - Should find more stable one?
+            conn.Host = "185.239.211.62";
+            conn.Port = 39215;
+
+            conn.Connect();
+
+            var players = conn.GetPlayersAsync();
+            var info = conn.GetInfoAsync();
+            var rules = conn.GetRulesAsync();
+            Assert.IsNotNull(players);
+            Assert.IsNotNull(info);
+            Assert.IsNotNull(rules);
         }
     }
 }

--- a/src/Okolni.Source.Query/Common/ByteHelper/ByteReader.cs
+++ b/src/Okolni.Source.Query/Common/ByteHelper/ByteReader.cs
@@ -107,6 +107,19 @@ namespace Okolni.Source.Common.ByteHelper
             return shortValue;
         }
 
+
+        /// <inheritdoc/>
+        public ushort GetUShort()
+        {
+            if (Remaining < 2)
+                throw new ArgumentOutOfRangeException("Not Enough bytes left to read");
+
+            ushort shortValue = BitConverter.ToUInt16(Response, Iterator);
+            Iterator += 2;
+
+            return shortValue;
+        }
+
         /// <inheritdoc/>
         public int GetInt()
         {
@@ -119,14 +132,40 @@ namespace Okolni.Source.Common.ByteHelper
             return intValue;
         }
 
+
         /// <inheritdoc/>
-        public uint GetLong()
+        public uint GetUInt()
         {
             if (Remaining < 4)
                 throw new ArgumentOutOfRangeException("Not Enough bytes left to read");
 
-            uint longValue = BitConverter.ToUInt32(Response, Iterator);
+            uint uintValue = BitConverter.ToUInt32(Response, Iterator);
             Iterator += 4;
+
+            return uintValue;
+        }
+
+
+        /// <inheritdoc/>
+        public long GetLong()
+        {
+            if (Remaining < 8)
+                throw new ArgumentOutOfRangeException("Not Enough bytes left to read");
+
+            long longValue = BitConverter.ToInt64(Response, Iterator);
+            Iterator += 8;
+
+            return longValue;
+        }
+
+        /// <inheritdoc/>
+        public ulong GetULong()
+        {
+            if (Remaining < 8)
+                throw new ArgumentOutOfRangeException("Not Enough bytes left to read");
+
+            ulong longValue = BitConverter.ToUInt64(Response, Iterator);
+            Iterator += 8;
 
             return longValue;
         }

--- a/src/Okolni.Source.Query/Common/ByteHelper/IByteReader.cs
+++ b/src/Okolni.Source.Query/Common/ByteHelper/IByteReader.cs
@@ -46,6 +46,14 @@
         /// <returns>the short number</returns>
         short GetShort();
 
+
+        /// <summary>
+        /// Extracts a ushort at the position of the iterator (16 Bit unsigned int)
+        /// </summary>
+        /// <returns>the ushort number</returns>
+        ushort GetUShort();
+
+
         /// <summary>
         /// Extracts an int at the position of the iterator
         /// </summary>
@@ -53,10 +61,23 @@
         int GetInt();
 
         /// <summary>
+        /// Extracts an uint at the position of the iterator
+        /// </summary>
+        /// <returns>the uint number</returns>
+        uint GetUInt();
+
+        /// <summary>
         /// Extracts a long at the position of the iterator
         /// </summary>
         /// <returns>the long number</returns>
-        uint GetLong();
+        long GetLong();
+
+        /// <summary>
+        /// Extracts a Ulong at the position of the iterator (64 bit unsigned number)
+        /// </summary>
+        /// <returns>the Ulong number</returns>
+        ulong GetULong();
+
 
         /// <summary>
         /// Extracts a float at the position of the iterator

--- a/src/Okolni.Source.Query/Common/Constants.cs
+++ b/src/Okolni.Source.Query/Common/Constants.cs
@@ -29,14 +29,14 @@ namespace Okolni.Source.Common
         public const byte A2S_RULES_RESPONSE = 0x45; //Ignoring C# naming conventions as of the original name defined by valve
 
         /// <summary>
-        /// The Header for a simple response
+        /// The Header for a simple response - Always equal to -1 (0xFFFFFFFF). Means it isn't split.
         /// </summary>
-        public const uint SimpleResponseHeader = 0xFFFFFFFF;
+        public const int SimpleResponseHeader = -1;
 
         /// <summary>
-        /// The Header for a multi packet response
+        /// The Header for a multi packet response - Always equal to -2 (0xFFFFFFFE). Means the packet is split. 
         /// </summary>
-        public const uint MultiPacketResponseHeader = 0xFFFFFFFE;
+        public const int MultiPacketResponseHeader = -2;
 
         /// <summary>
         /// The game id for 'The Ship'

--- a/src/Okolni.Source.Query/Common/Constants.cs
+++ b/src/Okolni.Source.Query/Common/Constants.cs
@@ -39,6 +39,36 @@ namespace Okolni.Source.Common
         public const int MultiPacketResponseHeader = -2;
 
         /// <summary>
+        /// Only  if ( EDF & 0x80 ) proves true: Will there be a port value (short)
+        /// </summary>
+        public const byte EDF_PORT = 0x80;
+
+
+
+        /// <summary>
+        /// Only  if ( EDF & 0x10 ) proves true:  Will there be the Server's SteamID (Long)
+        /// </summary>
+        public const byte EDF_STEAMID = 0x10;
+
+
+        /// <summary>
+        /// Only  if ( EDF & 0x40 ) proves true: Will there be SourceTV Information (Port and Name)
+        /// </summary>
+        public const byte EDF_SOURCETV = 0x40;
+
+        /// <summary>
+        /// Only if ( EDF & 0x20 ) proves true: String of keywords that describe the server
+        /// </summary>
+        public const byte EDF_KEYWORDS = 0x20;
+
+
+        /// <summary>
+        /// Only if if ( EDF & 0x01 ) proves true: Will there be the Sever's 64-Bit GameID (The server's 64-bit GameID. If this is present, a more accurate AppID is present in the low 24 bits. The earlier AppID could have been truncated as it was forced into 16-bit storage. )
+        /// </summary>
+        public const byte EDF_GAMEID = 0x01;
+
+
+        /// <summary>
         /// The game id for 'The Ship'
         /// </summary>
         public const short TheShipGameId = 2400;

--- a/src/Okolni.Source.Query/Common/Constants.cs
+++ b/src/Okolni.Source.Query/Common/Constants.cs
@@ -18,6 +18,12 @@ namespace Okolni.Source.Common
         /// </summary>
         public const byte A2S_INFO_RESPONSE = 0x49; //Ignoring C# naming conventions as of the original name defined by valve
 
+
+        /// <summary>
+        /// The byte indicator of the info response.
+        /// </summary>
+        public const byte A2S_INFO_RESPONSE_GOLDSOURCE = 0x6D; //Ignoring C# naming conventions as of the original name defined by valve
+
         /// <summary>
         /// The byte indicator of the player response.
         /// </summary>

--- a/src/Okolni.Source.Query/Common/MultiPacketResponse.cs
+++ b/src/Okolni.Source.Query/Common/MultiPacketResponse.cs
@@ -4,7 +4,7 @@ namespace Okolni.Source.Common
 {
     public class MultiPacketResponse
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public int Total { get; set; }
         public int Number { get; set; }
         public int Size { get; set; }

--- a/src/Okolni.Source.Query/Okolni.Source.Query.csproj
+++ b/src/Okolni.Source.Query/Okolni.Source.Query.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Florian Adler</Authors>
     <Product>Okolni Source Query</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Florian2406/Okolni-Source-Query</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageReleaseNotes>
-      1.2.0 Update to .Net Standard 2.1, Added ASync Methods, fix parsing of Extra Data Fields, Change InfoResponse Data Types align with Steam Query Protocol
+      2.0.0 Update to .Net Standard 2.1, Added ASync Methods, fix parsing of Extra Data Fields, Change InfoResponse Data Types align with Steam Query Protocol
       1.1.0 Added multipacket responses
       1.0.1 Fixed bug that occured when the server returned a challenge instead of the response directly
       1.0.0 Initial Fullrelease, fixed bug when calling functions repetetive
@@ -23,7 +23,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageId>Okolni.Source.Query</PackageId>
-    <FileVersion>1.2.0.0</FileVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Okolni.Source.Query/Okolni.Source.Query.csproj
+++ b/src/Okolni.Source.Query/Okolni.Source.Query.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Version>1.2.0</Version>
     <Authors>Florian Adler</Authors>
     <Product>Okolni Source Query</Product>

--- a/src/Okolni.Source.Query/Okolni.Source.Query.csproj
+++ b/src/Okolni.Source.Query/Okolni.Source.Query.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Florian Adler</Authors>
     <Product>Okolni Source Query</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/Florian2406/Okolni-Source-Query</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageReleaseNotes>
+      1.2.0 Added ASync Methods
       1.1.0 Added multipacket responses
       1.0.1 Fixed bug that occured when the server returned a challenge instead of the response directly
       1.0.0 Initial Fullrelease, fixed bug when calling functions repetetive
@@ -22,7 +23,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageId>Okolni.Source.Query</PackageId>
-    <FileVersion>1.1.0.0</FileVersion>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Okolni.Source.Query/Okolni.Source.Query.csproj
+++ b/src/Okolni.Source.Query/Okolni.Source.Query.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Florian2406/Okolni-Source-Query</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageReleaseNotes>
-      1.2.0 Added ASync Methods
+      1.2.0 Update to .Net Standard 2.1, Added ASync Methods, fix parsing of Extra Data Fields, Change InfoResponse Data Types align with Steam Query Protocol
       1.1.0 Added multipacket responses
       1.0.1 Fixed bug that occured when the server returned a challenge instead of the response directly
       1.0.0 Initial Fullrelease, fixed bug when calling functions repetetive

--- a/src/Okolni.Source.Query/Responses/InfoResponse.cs
+++ b/src/Okolni.Source.Query/Responses/InfoResponse.cs
@@ -41,22 +41,22 @@ namespace Okolni.Source.Query.Responses
         /// <summary>
         /// Steam Application ID of game. (Steam Application ID: https://developer.valvesoftware.com/wiki/Steam_Application_IDs)
         /// </summary>
-        public short ID { get; set; }
+        public ushort ID { get; set; }
 
         /// <summary>
         /// Number of players on the server.
         /// </summary>
-        public int Players { get; set; }
+        public byte Players { get; set; }
 
         /// <summary>
         /// Maximum number of players the server reports it can hold.
         /// </summary>
-        public int MaxPlayers { get; set; }
+        public byte MaxPlayers { get; set; }
 
         /// <summary>
         /// Number of bots on the server.
         /// </summary>
-        public int Bots { get; set; }
+        public byte Bots { get; set; }
 
         /// <summary>
         /// Indicates the type of server
@@ -88,7 +88,7 @@ namespace Okolni.Source.Query.Responses
         /// <summary>
         /// [ONLY AVAILABLE IF THE SERVER IS RUNNING 'The Ship'] The number of witnesses necessary to have a player arrested.
         /// </summary>
-        public int? Witnesses { get; set; }
+        public byte? Witnesses { get; set; }
 
         /// <summary>
         /// [ONLY AVAILABLE IF THE SERVER IS RUNNING 'The Ship'] Time (in seconds) before a player is arrested while being witnessed.
@@ -108,17 +108,17 @@ namespace Okolni.Source.Query.Responses
         /// <summary>
         /// if ( EDF & 0x80 ) proves true: The server's game port number.
         /// </summary>
-        public short? Port { get; set; }
+        public ushort? Port { get; set; }
 
         /// <summary>
         /// if ( EDF & 0x10 ) proves true: Server's SteamID.
         /// </summary>
-        public uint? SteamID { get; set; }
+        public ulong? SteamID { get; set; }
 
         /// <summary>
         /// if ( EDF & 0x40 ) proves true: Spectator port number for SourceTV.
         /// </summary>
-        public short? SourceTvPort { get; set; }
+        public ushort? SourceTvPort { get; set; }
 
         /// <summary>
         /// if ( EDF & 0x40 ) proves true: Name of the spectator server for SourceTV.
@@ -135,7 +135,7 @@ namespace Okolni.Source.Query.Responses
         /// If this is present, a more accurate AppID is present in the low 24 bits. 
         /// The earlier AppID could have been truncated as it was forced into 16-bit storage.
         /// </summary>
-        public uint? GameID { get; set; }
+        public ulong? GameID { get; set; }
 
         /// <summary>
         /// If the Server is a The Ship Server
@@ -184,14 +184,14 @@ namespace Okolni.Source.Query.Responses
             response += $" Environment: {Environment};";
             response += $" Visibility: {Visibility};";
             response += $" VAC: {VAC};";
-            if(IsTheShip)
+            if (IsTheShip)
             {
                 response += $" Mode: {Mode};";
                 response += $" Witnesses: {Witnesses};";
                 response += $" Duration: {Duration};";
             }
             response += $" Version: {Version};";
-            if(HasGameID || HasPort || HasKeywords || HasSourceTv || HasSteamID)
+            if (HasGameID || HasPort || HasKeywords || HasSourceTv || HasSteamID)
             {
                 if (HasPort)
                     response += $" Port: {Port};";

--- a/src/Okolni.Source.Query/Source/IQueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/IQueryConnection.cs
@@ -1,5 +1,7 @@
 ﻿using Okolni.Source.Query.Responses;
 using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
 
 namespace Okolni.Source.Query
 {
@@ -46,18 +48,50 @@ namespace Okolni.Source.Query
         /// Gets the A2S_INFO_RESPONSE from the server
         /// </summary>
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
         InfoResponse GetInfo(int maxRetries = 10);
 
         /// <summary>
         /// Gets the A2S_PLAYERS_RESPONSE from the server
         /// </summary>
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
         PlayerResponse GetPlayers(int maxRetries = 10);
 
         /// <summary>
         /// Gets the A2S_RULES_RESPONSE from the server
         /// </summary>
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
         RuleResponse GetRules(int maxRetries = 10);
+
+
+
+        /// <summary>
+        /// Gets the A2S_INFO_RESPONSE from the server
+        /// </summary>
+        /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
+        Task<InfoResponse> GetInfoAsync(int maxRetries = 10);
+
+        /// <summary>
+        /// Gets the A2S_PLAYERS_RESPONSE from the server
+        /// </summary>
+        /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
+        Task<PlayerResponse> GetPlayersAsync(int maxRetries = 10);
+
+        /// <summary>
+        /// Gets the A2S_RULES_RESPONSE from the server
+        /// </summary>
+        /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
+        Task<RuleResponse> GetRulesAsync(int maxRetries = 10);
     }
 }

--- a/src/Okolni.Source.Query/Source/IQueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/IQueryConnection.cs
@@ -50,6 +50,7 @@ namespace Okolni.Source.Query
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
         /// <exception cref="SocketException"></exception>
         /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         InfoResponse GetInfo(int maxRetries = 10);
 
         /// <summary>
@@ -58,6 +59,7 @@ namespace Okolni.Source.Query
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
         /// <exception cref="SocketException"></exception>
         /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         PlayerResponse GetPlayers(int maxRetries = 10);
 
         /// <summary>
@@ -66,6 +68,7 @@ namespace Okolni.Source.Query
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
         /// <exception cref="SocketException"></exception>
         /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         RuleResponse GetRules(int maxRetries = 10);
 
 
@@ -76,6 +79,7 @@ namespace Okolni.Source.Query
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
         /// <exception cref="SocketException"></exception>
         /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         Task<InfoResponse> GetInfoAsync(int maxRetries = 10);
 
         /// <summary>
@@ -84,6 +88,7 @@ namespace Okolni.Source.Query
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
         /// <exception cref="SocketException"></exception>
         /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         Task<PlayerResponse> GetPlayersAsync(int maxRetries = 10);
 
         /// <summary>
@@ -92,6 +97,7 @@ namespace Okolni.Source.Query
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
         /// <exception cref="SocketException"></exception>
         /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         Task<RuleResponse> GetRulesAsync(int maxRetries = 10);
     }
 }

--- a/src/Okolni.Source.Query/Source/QueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/QueryConnection.cs
@@ -174,6 +174,10 @@ namespace Okolni.Source.Query
                 var byteReader = requestData.reader;
                 var header = requestData.header;
 
+                if (header == Constants.A2S_INFO_RESPONSE_GOLDSOURCE)
+                    throw new ArgumentException("Obsolete GoldSource Response are not supported right now");
+
+
                 if (header != Constants.A2S_INFO_RESPONSE)
                     throw new ArgumentException("The fetched Response is no A2S_INFO Response.");
 

--- a/src/Okolni.Source.Query/Source/QueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/QueryConnection.cs
@@ -207,24 +207,24 @@ namespace Okolni.Source.Query
                 {
                     res.EDF = byteReader.GetByte();
 
-                    if ((res.EDF & 0x80) == 1)
+                    if ((res.EDF & Constants.EDF_PORT) == Constants.EDF_PORT)
                     {
                         res.Port = byteReader.GetUShort();
                     }
-                    if ((res.EDF & 0x10) == 1)
+                    if ((res.EDF & Constants.EDF_STEAMID) == Constants.EDF_STEAMID)
                     {
                         res.SteamID = byteReader.GetULong();
                     }
-                    if ((res.EDF & 0x40) == 1)
+                    if ((res.EDF & Constants.EDF_SOURCETV) == Constants.EDF_SOURCETV)
                     {
                         res.SourceTvPort = byteReader.GetUShort();
                         res.SourceTvName = byteReader.GetString();
                     }
-                    if ((res.EDF & 0x20) == 1)
+                    if ((res.EDF & Constants.EDF_KEYWORDS) == Constants.EDF_KEYWORDS)
                     {
                         res.KeyWords = byteReader.GetString();
                     }
-                    if ((res.EDF & 0x01) == 1)
+                    if ((res.EDF & Constants.EDF_GAMEID) == Constants.EDF_GAMEID)
                     {
                         res.GameID = byteReader.GetULong();
                     }

--- a/src/Okolni.Source.Query/Source/QueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/QueryConnection.cs
@@ -62,14 +62,7 @@ namespace Okolni.Source.Query
         /// <inheritdoc />
         public void Disconnect()
         {
-            if (m_udpClient != null)
-            {
-                if (m_udpClient.Client != null && m_udpClient.Client.Connected)
-                {
-                    m_udpClient.Client.Disconnect(false);
-                }
-                m_udpClient.Dispose();
-            }
+            m_udpClient?.Dispose();
         }
 
         private async Task Request(byte[] requestMessage)

--- a/src/Okolni.Source.Query/Source/QueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/QueryConnection.cs
@@ -95,7 +95,7 @@ namespace Okolni.Source.Query
         {
             var response = await ReceiveAsync();
             var byteReader = response.GetByteReader();
-            var header = byteReader.GetLong();
+            var header = byteReader.GetInt();
             if (header.Equals(Constants.SimpleResponseHeader))
                 return byteReader.GetRemaining();
             return await FetchMultiPacketResponse(byteReader);
@@ -103,7 +103,7 @@ namespace Okolni.Source.Query
 
         private async Task<byte[]> FetchMultiPacketResponse(IByteReader byteReader)
         {
-            var firstResponse = new MultiPacketResponse { Id = byteReader.GetLong(), Total = byteReader.GetByte(), Number = byteReader.GetByte(), Size = byteReader.GetShort(), Payload = byteReader.GetRemaining() };
+            var firstResponse = new MultiPacketResponse { Id = byteReader.GetInt(), Total = byteReader.GetByte(), Number = byteReader.GetByte(), Size = byteReader.GetShort(), Payload = byteReader.GetRemaining() };
 
             var compressed = (firstResponse.Id & 2147483648) == 2147483648; // Check for compression
 
@@ -112,13 +112,13 @@ namespace Okolni.Source.Query
             {
                 var response = m_udpClient.Receive(ref m_endPoint);
                 var multiResponseByteReader = response.GetByteReader();
-                var header = multiResponseByteReader.GetLong();
+                var header = multiResponseByteReader.GetInt();
                 if (header != Constants.MultiPacketResponseHeader)
                 {
                     i--;
                     continue;
                 }
-                var id = multiResponseByteReader.GetLong();
+                var id = multiResponseByteReader.GetInt();
                 if (id != firstResponse.Id)
                 {
                     i--;
@@ -133,7 +133,7 @@ namespace Okolni.Source.Query
             if (compressed)
                 throw new NotImplementedException("Compressed responses are not yet implemented");
 
-            var payloadHeader = assembledPayloadByteReader.GetLong();
+            var payloadHeader = assembledPayloadByteReader.GetUInt();
 
             return assembledPayloadByteReader.GetRemaining();
         }
@@ -185,7 +185,7 @@ namespace Okolni.Source.Query
                 res.Map = byteReader.GetString();
                 res.Folder = byteReader.GetString();
                 res.Game = byteReader.GetString();
-                res.ID = byteReader.GetShort();
+                res.ID = byteReader.GetUShort();
                 res.Players = byteReader.GetByte();
                 res.MaxPlayers = byteReader.GetByte();
                 res.Bots = byteReader.GetByte();
@@ -209,15 +209,15 @@ namespace Okolni.Source.Query
 
                     if ((res.EDF & 0x80) == 1)
                     {
-                        res.Port = byteReader.GetShort();
+                        res.Port = byteReader.GetUShort();
                     }
                     if ((res.EDF & 0x10) == 1)
                     {
-                        res.SteamID = byteReader.GetLong();
+                        res.SteamID = byteReader.GetULong();
                     }
                     if ((res.EDF & 0x40) == 1)
                     {
-                        res.SourceTvPort = byteReader.GetShort();
+                        res.SourceTvPort = byteReader.GetUShort();
                         res.SourceTvName = byteReader.GetString();
                     }
                     if ((res.EDF & 0x20) == 1)
@@ -226,7 +226,7 @@ namespace Okolni.Source.Query
                     }
                     if ((res.EDF & 0x01) == 1)
                     {
-                        res.GameID = byteReader.GetLong();
+                        res.GameID = byteReader.GetULong();
                     }
                 }
 
@@ -273,7 +273,7 @@ namespace Okolni.Source.Query
                     {
                         Index = byteReader.GetByte(),
                         Name = byteReader.GetString(),
-                        Score = byteReader.GetLong(),
+                        Score = byteReader.GetUInt(),
                         Duration = TimeSpan.FromSeconds(byteReader.GetFloat())
                     });
                 }
@@ -284,8 +284,8 @@ namespace Okolni.Source.Query
                     playerResponse.IsTheShip = true;
                     for (int i = 0; i < playercount; i++)
                     {
-                        playerResponse.Players[i].Deaths = byteReader.GetLong();
-                        playerResponse.Players[i].Money = byteReader.GetLong();
+                        playerResponse.Players[i].Deaths = byteReader.GetUInt();
+                        playerResponse.Players[i].Money = byteReader.GetUInt();
                     }
                 }
 


### PR DESCRIPTION
This adds ASync Query Methods to QueryConnection.

The SendTimeout and ReceiveTimeout properties on the Socket only apply to Synchronous Send/Receive. There are ReceiveAsync and SendAsync method overloads on Socket in .NET Standard 2.1 that support CancellationToken, but that would mean dropping support for .Net Framework. For now, there is a slightly hacky workaround I used.

- Implemented ASync Methods
- Updated Example to include ASync Methods
- Updated Test Server to working one
- Added Tests for ASync methods and for timeout/failure
- Fixed errors with the Disconnect method, since this is all UDP based all we need to do is dispose the UDPClient to free the socket.
