### PR TITLE
"Raw" response property in RulesResponse

### DIFF
--- a/src/Okolni.Source.Query/Okolni.Source.Query.csproj
+++ b/src/Okolni.Source.Query/Okolni.Source.Query.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Florian Adler</Authors>
     <Product>Okolni Source Query</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/Florian2406/Okolni-Source-Query</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageReleaseNotes>
+      2.1.0 Added RawResponse to the RulesResponse
       2.0.0 Update to .Net Standard 2.1, Added ASync Methods, fix parsing of Extra Data Fields, Change InfoResponse Data Types align with Steam Query Protocol
       1.1.0 Added multipacket responses
       1.0.1 Fixed bug that occured when the server returned a challenge instead of the response directly

--- a/src/Okolni.Source.Query/Responses/RuleResponse.cs
+++ b/src/Okolni.Source.Query/Responses/RuleResponse.cs
@@ -15,5 +15,10 @@ namespace Okolni.Source.Query.Responses
         /// Dictionary of Rules on the Server
         /// </summary>
         public Dictionary<string, string> Rules { get; set; }
+        
+        /// <summary>
+        /// The response obtained from the server without any processing.
+        /// </summary>
+        public byte[] RawResponse { get; set; }
     }
 }

--- a/src/Okolni.Source.Query/Source/IQueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/IQueryConnection.cs
@@ -72,15 +72,6 @@ namespace Okolni.Source.Query
         RuleResponse GetRules(int maxRetries = 10);
 
         /// <summary>
-        /// Gets the A2S_RULES_RESPONSE from the server and returns the raw byte[]
-        /// </summary>
-        /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
-        /// <exception cref="SocketException"></exception>
-        /// <exception cref="TimeoutException"></exception>
-        /// <exception cref="ArgumentException"></exception>
-        Task<byte[]> GetRawRulesAsync(int maxRetries = 10);
-
-        /// <summary>
         /// Gets the A2S_INFO_RESPONSE from the server
         /// </summary>
         /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>

--- a/src/Okolni.Source.Query/Source/IQueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/IQueryConnection.cs
@@ -71,7 +71,14 @@ namespace Okolni.Source.Query
         /// <exception cref="ArgumentException"></exception>
         RuleResponse GetRules(int maxRetries = 10);
 
-
+        /// <summary>
+        /// Gets the A2S_RULES_RESPONSE from the server and returns the raw byte[]
+        /// </summary>
+        /// <param name="maxRetries">How often the get info should be retried if the server responds with a challenge request</param>
+        /// <exception cref="SocketException"></exception>
+        /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        Task<byte[]> GetRawRulesAsync(int maxRetries = 10);
 
         /// <summary>
         /// Gets the A2S_INFO_RESPONSE from the server

--- a/src/Okolni.Source.Query/Source/QueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/QueryConnection.cs
@@ -342,6 +342,26 @@ namespace Okolni.Source.Query
             }
         }
 
+        public async Task<byte[]> GetRawRulesAsync(int maxRetries = 10)
+        {
+            try
+            {
+                var requestData = await RequestDataFromServer(Constants.A2S_RULES_CHALLENGE_REQUEST, maxRetries, true);
+
+                var byteReader = requestData.reader;
+                var header = requestData.header;
+
+                if (!header.Equals(Constants.A2S_RULES_RESPONSE))
+                    throw new ArgumentException("Response was no rules response.");
+
+                return byteReader.GetBytes(byteReader.Remaining);
+            }
+            catch (Exception ex)
+            {
+                throw new SourceQueryException("Could not gather Rules", ex);
+            }
+        }
+
         public async Task<(IByteReader reader, byte header)> RequestDataFromServer(byte[] request, int maxRetries, bool replaceLastBytesInRequest = false)
         {
             await Request(request);

--- a/src/Okolni.Source.Query/Source/QueryConnection.cs
+++ b/src/Okolni.Source.Query/Source/QueryConnection.cs
@@ -327,7 +327,7 @@ namespace Okolni.Source.Query
                 if (!header.Equals(Constants.A2S_RULES_RESPONSE))
                     throw new ArgumentException("Response was no rules response.");
 
-                RuleResponse ruleResponse = new RuleResponse() { Header = header, Rules = new Dictionary<string, string>() };
+                RuleResponse ruleResponse = new RuleResponse() { Header = header, Rules = new Dictionary<string, string>(), RawResponse = byteReader.Response};
                 int rulecount = byteReader.GetShort();
                 for (int i = 1; i <= rulecount; i++)
                 {
@@ -335,26 +335,6 @@ namespace Okolni.Source.Query
                 }
 
                 return ruleResponse;
-            }
-            catch (Exception ex)
-            {
-                throw new SourceQueryException("Could not gather Rules", ex);
-            }
-        }
-
-        public async Task<byte[]> GetRawRulesAsync(int maxRetries = 10)
-        {
-            try
-            {
-                var requestData = await RequestDataFromServer(Constants.A2S_RULES_CHALLENGE_REQUEST, maxRetries, true);
-
-                var byteReader = requestData.reader;
-                var header = requestData.header;
-
-                if (!header.Equals(Constants.A2S_RULES_RESPONSE))
-                    throw new ArgumentException("Response was no rules response.");
-
-                return byteReader.GetBytes(byteReader.Remaining);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
On clients using this library for games such as DayZ, parsing the Rules response into a Dictionary<string,string> will break the client logic. 

DayZ implements a variation of the rules response, based on Arma 3 protocol explained here: https://community.bistudio.com/wiki/Arma_3:_ServerBrowserProtocol3

Allowing clients to obtain the response from the server without any treatment will allow implementing additional logic that may be required by the game. 

I thought it would be interesting to have such data in the RulesResponse so I've added the RawResponse property to the object. 



